### PR TITLE
Initial implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # hof-util-reqres
 Test helper to create dummy request/response objects for testing middleware methods
+
+## Usage
+
+In your tests you can use the provided `req` and `res` methods to create objects with additional properties that we would expect to exist on a request that had passed through a hof request pipeline.
+
+```js
+const request = require('hof-util-reqres').req;
+const req = request();
+
+it('provides a sessionModel property on the request', () => {
+  expect(req.sessionModel).to.be.an.instanceOf(require('hof-model'));
+});
+
+it('provides a translate property on the request', () => {
+  expect(req.translate).to.be.a('function');
+});
+
+it('provides a form property on the request with values', () => {
+  expect(req.form).to.eql({ values: {} });
+});
+```
+
+Additionally, the request and response objects will have all properties and methods exposed by express. Response methods will be instances of sinon stubs, and so can have assertions made against their calls.
+
+See [reqres](https://npmjs.com/reqres) module for further details of default express behaviour.
+
+## Session Data
+
+The session model can be pre-populated by passing a `session` option.
+
+```js
+const request = require('hof-util-reqres').req;
+const req = request({
+  session: { name: 'Alice' }
+});
+
+it('populates session model with `session` parameter', () => {
+  expect(req.sessionModel.get('name')).to.equal('Alice');
+});
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/reqres');

--- a/lib/reqres.js
+++ b/lib/reqres.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  req: require('./request'),
+  res: require('./response')
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const reqres = require('reqres');
+const Model = require('hof-model');
+
+module.exports = function request(opts) {
+  opts = opts || {};
+  const req = reqres.req(opts);
+  req.form = req.form || {};
+  req.form.values = req.form.values || {};
+  req.sessionModel = new Model(opts.session);
+  req.translate = key => key;
+  return req;
+};

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('reqres').res;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hof-util-reqres",
+  "version": "1.0.0",
+  "description": "Test helper to create dummy request/response objects for testing middleware methods",
+  "main": "index.js",
+  "scripts": {
+    "test": "eslint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UKHomeOfficeForms/hof-util-reqres.git"
+  },
+  "author": "UKHomeOffice",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/UKHomeOfficeForms/hof-util-reqres/issues"
+  },
+  "homepage": "https://github.com/UKHomeOfficeForms/hof-util-reqres#readme",
+  "devDependencies": {
+    "eslint": "^3.17.1",
+    "eslint-config-homeoffice": "^2.1.2"
+  },
+  "dependencies": {
+    "hof-model": "^3.0.0",
+    "reqres": "^1.2.2"
+  }
+}


### PR DESCRIPTION
Adds basic request helper to augment request with things that we'd expect to be on a request that's passed through hof.

Extends [reqres](https://npmjs.com/reqres) with hof things so I don't end up with [this](https://github.com/UKHomeOffice/firearms/blob/master/test/helpers/request.js) in every single project.