### PR TITLE
Add req.form.options to stub hof request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -8,6 +8,7 @@ module.exports = function request(opts) {
   const req = reqres.req(opts);
   req.form = req.form || {};
   req.form.values = req.form.values || {};
+  req.form.options = req.form.options || {};
   req.sessionModel = new Model(opts.session);
   req.translate = key => key;
   req.log = () => {};


### PR DESCRIPTION
Since downstream methods will often make use of the options present on req.form then make sure they exist by default.